### PR TITLE
proprietary: Pin a source-built gralloc and libqdMetaData

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -600,6 +600,14 @@ vendor/lib64/vendor.qti.hardware.qdutils_disp@1.0.so
 vendor/lib/libsdedrm.so|b603b6beaa50d49604ab2ebe0977a9ef79252b20
 vendor/lib64/libsdedrm.so|2add69c575f5745d0db2bbe8dfb7f75f9dc03ce6
 
+# DISPLAY_GRALLOC
+vendor/lib/hw/gralloc.default.so|f245d2a6624e0f0fa501add5f405ffe811a4ef2c
+vendor/lib/hw/gralloc.msm8998.so|52dec8a00298a3096cfac7fa62ef10efd641b76e
+vendor/lib/libqdMetaData.so|19dbe9a16251fcf21b6c65198acbe85ab0bbbd8d
+vendor/lib64/hw/gralloc.default.so|7d9ed576cd15fb199e13203a391df4747b72454f
+vendor/lib64/hw/gralloc.msm8998.so|e0da90c598f44454fd6077e6fa84092361c11e83
+vendor/lib64/libqdMetaData.so|84cac8c2b78cca0988fbf53b3b670bf1bc11a635
+
 # DISPLAY_HDR - from DRG - QKQ1.190828.002
 vendor/lib/libhdr_tm.so|8d253c28c1fd976ac009088e36d483c16566f9a5
 vendor/lib64/libhdr_tm.so|1e74de5b505c8f742f1fb0379725ec9f5fd53282


### PR DESCRIPTION
Using the yoshino (msm8998) P stock camera stack in 10 results in two issues.

1) The camera libraries appear to rely on a specific internal structure of private_handle_t. With the padding introduced in commit https://github.com/LineageOS/android_hardware_qcom_display/commit/3aad4a11e276fb7101185d0b152e208a32829d31 a camera memory leak occurs.

2) Mitigating the camera leak, and with the introduction of IMapper::2.1 in commit https://github.com/LineageOS/android_hardware_qcom_display/commit/4adcbb388d596dc08a7c1cdc9870394af0c20b51 pictures at ISO values of 50 are normal, have artefacts at 100-200 and a green tint at any values above 200. This happens when the 'offset' value of the imported private_handle_t becomes initialized to 0.

Both issues are likely linked to a modification of Sony in the members of private_handle_t.

This would normally be easy to fix via a build flag and ifdef/ifndef statements. However since CAF, in their eternal wisdom, removed the Android.mk from libqdutils, no flags can be passed conditionally using the Android.bp. For the same reason, we also cannot make use of TARGET_SPECIFIC_HEADER_PATH. So let's pin a pre-built gralloc and libqdMetaData for now until we have figured this out. The following modifications are applied to hardware/qcom-caf/msm8998/display :

```
diff --git a/gralloc/gr_buf_mgr.cpp b/gralloc/gr_buf_mgr.cpp
index c7cfd1df7..456192bc5 100644
--- a/gralloc/gr_buf_mgr.cpp
+++ b/gralloc/gr_buf_mgr.cpp
@@ -253,7 +253,7 @@ gralloc1_error_t BufferManager::ImportHandleLocked(private_handle_t *hnd) {
   }
   // Initialize members that aren't transported
   hnd->size = static_cast<unsigned int>(lseek(hnd->fd, 0, SEEK_END));
-  hnd->offset = 0;
+  //hnd->offset = 0;
   hnd->offset_metadata = 0;
   hnd->base = 0;
   hnd->base_metadata = 0;
diff --git a/gralloc/gr_priv_handle.h b/gralloc/gr_priv_handle.h
index 2acb16cc4..6a4917e47 100644
--- a/gralloc/gr_priv_handle.h
+++ b/gralloc/gr_priv_handle.h
@@ -36,8 +36,6 @@ typedef gralloc1_error_t (*GRALLOC1_PFN_PERFORM)(gralloc1_device_t *device, int

 #define PRIV_HANDLE_CONST(exp) static_cast<const private_handle_t *>(exp)

-#pragma pack(push, 4)
-
 #ifdef __cplusplus
 struct private_handle_t : public native_handle_t {
 #else
@@ -200,6 +198,5 @@ struct private_handle_t {
   uint64_t GetBackingstore() const { return id; }
 #endif
 };
-#pragma pack(pop)

 #endif  // __GR_PRIV_HANDLE_H__
```