### PR TITLE
lilac: proprietary-files-vendor: kill liboemcrypto

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -949,7 +949,6 @@ vendor/lib/libcppf.so
 vendor/lib/libdiag.so
 vendor/lib/libdrmfs.so
 vendor/lib/libdrmtime.so
-vendor/lib/liboemcrypto.so
 vendor/lib/libqisl.so
 vendor/lib/librpmb.so
 vendor/lib/libsecureui.so
@@ -970,7 +969,6 @@ vendor/lib64/libbase64.so
 vendor/lib64/libdiag.so
 vendor/lib64/libdrmfs.so
 vendor/lib64/libdrmtime.so
-vendor/lib64/liboemcrypto.so
 vendor/lib64/libqisl.so
 vendor/lib64/librpmb.so
 vendor/lib64/libsecureui.so


### PR DESCRIPTION
* this make users with L1 widevine(actually unstable due to sony propietary "implementations") fallback to L3
  fixing crashes on apps that use DRM video content(like netflix, primevideo,etc.)