### PR TITLE
lilac: extract: Don't add Sony camera service to camera-daemon tasks

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -80,4 +80,10 @@ fix_product_path product/etc/permissions/lpa.xml
 fix_product_path product/etc/permissions/qcrilhook.xml
 fix_product_path product/etc/permissions/telephonyservice.xml
 
+#
+# Don't add Sony camera service to camera-daemon tasks
+#
+
+sed -i 's/\/dev\/cpuset\/camera-daemon\/tasks //g' "${DEVICE_ROOT}"/vendor/etc/init/vendor.somc.hardware.camera.provider@1.0-service.rc
+
 "${MY_DIR}"/setup-makefiles.sh


### PR DESCRIPTION
Now that we generate the camera-daemon cpuset earlier, the Sony camera service pid is actually added to its tasks.

Unfortunately, this causes the respective cpu's to be stuck on the highest frequencies. Before (and on stock) we never encountered this issue, since the cpuset was generated after this service was started.

Fix this by not adding the vendor.somc.hardware.camera.provider@1.0-service pid to /dev/cpuset/camera-daemon/tasks