### PR TITLE
Remove wvkbd

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -667,7 +667,6 @@ vendor/lib64/com.qualcomm.qti.dpm.api@1.0.so|ab5d46cbf14ce90ab44aaab4dc1520378c5
 vendor/lib64/libdpmqmihal.so|d5b8330b56d7e0c036b00a817754748bf3137774
 
 # DRM
-vendor/bin/wvkbd
 vendor/bin/hw/android.hardware.drm@1.1-service.widevine
 vendor/etc/init/android.hardware.drm@1.1-service.widevine.rc
 vendor/firmware/tzwidevine.b00


### PR DESCRIPTION
This depends on the removed liboemcrypto.so and is not actually required
Depends on https://github.com/whatawurst/android_device_sony_yoshino-common/pull/65