### PR TITLE
lilac: proprietary: Drop unneeded vendor.somc.hardware.wifi service

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -486,7 +486,4 @@ vendor/etc/firmware/tztpm.b07
 vendor/etc/firmware/tztpm.mdt
 
 # WIFI
-vendor/bin/hw/vendor.somc.hardware.wifi@2.0-service
 vendor/etc/wifi/bdwlan.bin
-vendor/lib64/vendor.somc.hardware.wifi.supplicant@2.0.so
-vendor/lib64/vendor.somc.hardware.wifi@2.0.so


### PR DESCRIPTION
Change-Id: I68f663d9659088d6d0009da30c3cd94bc8eeea74