### PR TITLE
lilac: Drop keyprovd service

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -317,9 +317,6 @@ vendor/firmware/ipa_fws.b01
 vendor/firmware/ipa_fws.elf
 vendor/firmware/ipa_fws.mdt
 
-# KEYPROVD
-vendor/bin/keyprovd
-
 # KOBJEVENTD
 vendor/bin/hw/kobjeventd
 vendor/lib/kobjeventd/touch_cover.so


### PR DESCRIPTION
For some reason, this service randomly hangs at boot sometimes.

Seeing as we dont run on unlocked BL's anyway, and suntory will not pass, let's just remove it.