### PR TITLE
lilac: overlay: Enable VoLTE and VoWiFi for Congstar

### DIFF
--- a/rro_overlays/CarrierConfigOverlay/res/xml/vendor.xml
+++ b/rro_overlays/CarrierConfigOverlay/res/xml/vendor.xml
@@ -336,12 +336,16 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="262" mnc="01" spn="congstar">
-        <boolean name="carrier_volte_available_bool" value="false" />
-        <boolean name="carrier_wfc_ims_available_bool" value="false" />
+        <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="262" mnc="01" spn="congstar.de">
-        <boolean name="carrier_volte_available_bool" value="false" />
-        <boolean name="carrier_wfc_ims_available_bool" value="false" />
+        <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
     </carrier_config>
 
     <!-- Carrier-specific Vodafone DE -->


### PR DESCRIPTION
We have the mbn and it's enabled and working for poplar and maple. So follow suit and enable it for lilac as well.