### PR TITLE
Fix bluetooth.controller.voltage

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -3,6 +3,9 @@
     <item name="none">0</item>
     <item name="screen.on.display0">29.93</item>
     <item name="bluetooth.active">37.68</item>
+    <item name="bluetooth.controller.idle">1</item>
+    <item name="bluetooth.controller.rx">25</item>
+    <item name="bluetooth.controller.tx">25</item>
     <item name="bluetooth.controller.voltage">3300</item>
     <item name="bluetooth.on">0.89</item>
     <item name="screen.full.display0">247.57</item>
@@ -174,8 +177,4 @@
         <value>.2</value>
         <value>2</value>
     </array>
-    <item name="bluetooth.controller.idle">1</item>
-    <item name="bluetooth.controller.rx">25</item>
-    <item name="bluetooth.controller.tx">25</item>
-    <item name="bluetooth.controller.voltage">3600</item>
 </device>


### PR DESCRIPTION
It was contained 2 times in power_profile.xml likely making it use the wrong 3600 value while according to other changes 3300 is intended

Moved the values together to make this abvious